### PR TITLE
Fix bug where exception will occur if user click close button twice

### DIFF
--- a/src/Livewire/Concerns/HasState.php
+++ b/src/Livewire/Concerns/HasState.php
@@ -10,10 +10,10 @@ trait HasState
 
     public function closeActionable(?string $actionable): void
     {
-        if (!$actionable) {
-            retrun;
+        if ($actionable === null) {
+            return;
         }
-        
+
         if ($this->actionableId !== $actionable) {
             return;
         }

--- a/src/Livewire/Concerns/HasState.php
+++ b/src/Livewire/Concerns/HasState.php
@@ -8,8 +8,12 @@ trait HasState
 
     public bool $actionableOpen = false;
 
-    public function closeActionable(string $actionable): void
+    public function closeActionable(?string $actionable): void
     {
+        if (!$actionable) {
+            retrun;
+        }
+        
         if ($this->actionableId !== $actionable) {
             return;
         }


### PR DESCRIPTION
Hi Ralph! 
I found out a bug when using the packages and here i come for an solution 😆 

## Expected Behavior
Livewire Exception should not pop up when user click close button twice

## Current Behavior
Livewire would pop up exception error when user click close button twice 

## Steps to Reproduce
1. Create a modal with dismissable attribute
2. Click 'Close' button twice or Spam the close button
3. Wait for few second
4. Livewire pop up 500 server error 

![Screenshot 2022-12-16 at 11 12 37 AM](https://user-images.githubusercontent.com/43839286/208013576-884da4ec-1576-44ba-a10f-023bc86c02d6.png)

To me the obvious way to fix this bug is to allowing the `$actionableId` accept null value and return if its not present. 

Please let me know your thought!